### PR TITLE
Update triggerbuild.yml

### DIFF
--- a/.github/workflows/triggerbuild.yml
+++ b/.github/workflows/triggerbuild.yml
@@ -17,5 +17,5 @@ jobs:
          COMMIT_MESSAGE: 'Committing timestamp PR to trigger build'
          COMMIT_NAME: 'GitHub Actions'
          COMMIT_EMAIL: 'devops@dwolla.com'
-         PR_BRANCH_NAME: 'triggerbuild-${PR_ID}'
+         PR_BRANCH_NAME: 'main'
          PR_TITLE: 'Commit timestamp PR to trigger build'


### PR DESCRIPTION
Push directly to main (will validate this works once repo is properly restricted) to trigger build w/o needing manual approval.